### PR TITLE
Refactor dynamic imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can configure the behavior of descent.js by passing different arguments to D
 ### Presets
 
 - `'browser'`
-  Use this preset when using the library in a browser environment. It will attempt to connect using window.ethereum or window.web3.
+  Use this preset when using the library in a browser environment. It will attempt to connect using window.ethereum or window.web3. Make sure you pass in the connected browser provider instance
 
 - `'https'`
   Connect to a JSON-RPC node. Requires url to be set in the options.
@@ -132,11 +132,12 @@ const descent = await Descent.create('https', {
 
 1. [Methods](#methods)
    - [1. getVaultInfo(ownerAddress: string)](#getvaultinfo)
-   - [2. depositCollateral(collateralAmount: string)](#depositcollateral)
-   - [3. borrowCurrency(borrowAmount: string)](#borrowcurrency)
-   - [4. repayCurrency(amount: string)](#repaycurrency)
-   - [5. withdrawCollateral(collateralAmount: string)](#withdrawcollateral)
-   - [6. getCollateralInfo()](#getcollateralinfo)
+   - [2. setupVault()](#setupVault)
+   - [3. depositCollateral(collateralAmount: string)](#depositcollateral)
+   - [4. borrowCurrency(borrowAmount: string)](#borrowcurrency)
+   - [5. repayCurrency(amount: string)](#repaycurrency)
+   - [6. withdrawCollateral(collateralAmount: string)](#withdrawcollateral)
+   - [7. getCollateralInfo()](#getcollateralinfo)
 
 ### methods
 
@@ -168,6 +169,18 @@ Gets detailed information about a vault specified by the owner's address.
      availablexNGN: '244499.769094051707348'
     }
 ```
+
+#### setupVault
+
+```ts
+descent.setupVault(): Promise<{}>
+```
+
+Initializes a vault for a first time user and sets up the appropriate configuration for the vault on the ssmart contract
+
+**Returns:**
+
+- A promise resolving to the transaction object.
 
 #### depositCollateral
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -34,9 +34,6 @@ esbuild.build({
                 path: args.path.replace('/lib/', '/lib.esm/') + '.js',
                 external: true,
               };
-            if (args.path.startsWith('./') || args.path.startsWith('../'))
-              return { path: args.path + '.mjs', external: true };
-            return { path: args.path, external: true };
           }
         });
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descent-protocol/sdk",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "description": "A Typescript library for interacting with the Descent Protocol",
   "keywords": [
     "xNGN",
@@ -15,8 +15,9 @@
   "license": "MIT",
   "author": "Njoku Emmanuel",
   "type": "module",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "browser": "dist/index.bundle.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
@@ -79,6 +80,7 @@
     "dev": "concurrently -c yellow,blue -n RLP,SRV \"npm:build:watch\" \"npm:serve\"",
     "build:types": "tsc --emitDeclarationOnly --project tsconfig.build.json",
     "build": "node esbuild.js",
+    "build:rollup": "rollup -c",
     "test": "jest --coverage ./test/",
     "test:getter": "jest ./test/getters.test.ts",
     "test:vault": "jest ./test/vault.test.ts",
@@ -94,7 +96,7 @@
     "transformIgnorePatterns": [
       "node_modules"
     ],
-    "moduleFileExtension": [
+    "moduleFileExtensions": [
       "js",
       "mjs",
       "cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descent-protocol/sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A Typescript library for interacting with the Descent Protocol",
   "keywords": [
     "xNGN",

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,54 +1,12 @@
-import { getContractAddress } from './getContractAddresses';
-import { ContractName, SupportedNetwork } from './types';
-import type { Signer, Provider, BaseContract, Interface } from 'ethers';
-import {
-  Currency,
-  Feed,
-  MultiStaticcall,
-  USDC,
-  Vault,
-  VaultGetters,
-  VaultRouter,
-} from '../generated';
+import { InterfaceAbi, Signer, ethers } from 'ethers';
 
-type BaseFactory = {
-  readonly abi: object;
-  createInterface(): Interface;
-  connect(address: string, signerOrProvider: Signer | Provider): BaseContract;
+/**
+ * This is a contract object that is used to interact with the smart contract.
+ * @param {string} provider - The provider to use for the contract.
+ * @param {string} contractAddress - The address of the contract.
+ * @param {array} abi - The abi of the contract.
+ */
+
+export const Contract = (contractAddress: string, abi: InterfaceAbi, signer: Signer) => {
+  return new ethers.Contract(contractAddress, abi, signer);
 };
-
-export default class ContractManager {
-  private signerOrProvider: Signer | Provider;
-
-  constructor(signerOrProvider: Signer | Provider) {
-    this.signerOrProvider = signerOrProvider;
-  }
-
-  private generateContractGetter = <C extends BaseContract>(
-    name: ContractName,
-  ): ((passedProvider?: any) => Promise<C>) => {
-    return async (passedProvider) => {
-      const mod = await import(`../generated/factories/${name}__factory`);
-
-      let chainId;
-      let inputAddress;
-      chainId = (await this.signerOrProvider.provider!.getNetwork()).chainId.toString(10);
-
-      inputAddress = (getContractAddress(name) || {})[chainId];
-
-      if (!inputAddress) {
-        throw new Error(`No address for contract ${name}`);
-      }
-      return mod[`${name}__factory`]?.connect(inputAddress, this.signerOrProvider);
-    };
-  };
-
-  public getVaultGetterContract = this.generateContractGetter<VaultGetters>('VaultGetters');
-  public getVaultRouterContract = this.generateContractGetter<VaultRouter>('VaultRouter');
-  public getVaultContract = this.generateContractGetter<Vault>('Vault');
-  public getMultistaticcallContract =
-    this.generateContractGetter<MultiStaticcall>('MultiStaticcall');
-  public getCurrencyContract = this.generateContractGetter<Currency>('Currency');
-  public getUSDCContract = this.generateContractGetter<USDC>('USDC');
-  public getFeedContract = this.generateContractGetter<Feed>('Feed');
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   burnCurrency,
   collateralizeVault,
   mintCurrency,
+  setupVault,
   withdrawCollateral,
 } from './services/vault';
 import { Transaction } from './libs/transactions';
@@ -147,7 +148,19 @@ export class DescentClass {
 
     return result;
   }
+
+  /**
+   * @dev initializes a vault for a an address
+   * @returns transaction obj
+   */
+  public async setupVault() {
+    const owner = await this.signer.getAddress();
+    const result = await setupVault(owner, this.chainId, this.transaction, this.internal);
+
+    return result;
+  }
 }
+
 async function create(
   mode: string,
   options: {
@@ -180,15 +193,6 @@ async function create(
   }
 
   const descent = new DescentClass(signer, provider, options.collateral, mode, chainId);
-
-  // approve router to talk to vault on behalf of user
-  // MOVE THIS TO IT'S OWN METHOD
-  // const vaultRouter: any = getContractAddress('VaultRouter')[chainId];
-
-  // const relyResponse = (await contracts.getVaultContract()).rely(vaultRouter);
-  // (await relyResponse).wait();
-
-  // await waitTime(50);
 
   return descent;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import { Eip1193Provider, SigningKey, ethers } from 'ethers';
-import { ICollateral, IMode, ISigner } from './types';
+import { ICollateral, IContract, IMode, ISigner } from './types';
 import { Signer, Provider } from 'ethers';
 
 import { SupportedNetwork } from './contracts/types';
-import ContractManager from './contracts';
 import { waitTime } from './libs/utils';
 import {
   burnCurrency,
@@ -21,7 +20,6 @@ export class DescentClass {
   protected provider: Provider;
   private collateral: ICollateral;
 
-  contracts?: ContractManager;
   configMode: IMode | string;
   chainId: string;
 
@@ -33,14 +31,12 @@ export class DescentClass {
     signer: Signer,
     provider: Provider,
     collateral: ICollateral,
-    contracts: ContractManager,
     configMode: IMode | string,
     chainId: string,
   ) {
     this.provider = provider;
     this.signer = signer;
     this.collateral = collateral;
-    this.contracts = contracts;
     this.configMode = configMode;
     this.chainId = chainId;
   }
@@ -55,8 +51,8 @@ export class DescentClass {
       this.collateral,
       ownerAddress,
       this.chainId,
-      this.contracts!,
       this.internal,
+      this.signer,
     );
 
     return result;
@@ -67,12 +63,7 @@ export class DescentClass {
    * @returns The collateral information
    */
   public async getCollateralInfo() {
-    const result = await getCollateralData(
-      this.collateral,
-
-      this.chainId,
-      this.contracts!,
-    );
+    const result = await getCollateralData(this.collateral, this.chainId, this.signer);
 
     return result;
   }
@@ -91,7 +82,7 @@ export class DescentClass {
       this.chainId,
       this.transaction,
       this.internal,
-      this.contracts!,
+      this.signer,
     );
 
     return result;
@@ -111,7 +102,7 @@ export class DescentClass {
       this.chainId,
       this.transaction,
       this.internal,
-      this.contracts!,
+      this.signer,
     );
 
     return result;
@@ -131,7 +122,7 @@ export class DescentClass {
       this.chainId,
       this.transaction,
       this.internal,
-      this.contracts!,
+      this.signer,
     );
 
     return result;
@@ -188,18 +179,16 @@ async function create(
     throw new Error(`chainId '${chainId}' is not supported.`);
   }
 
-  const contracts = new ContractManager(signer);
-
-  const descent = new DescentClass(signer, provider, options.collateral, contracts, mode, chainId);
+  const descent = new DescentClass(signer, provider, options.collateral, mode, chainId);
 
   // approve router to talk to vault on behalf of user
+  // MOVE THIS TO IT'S OWN METHOD
+  // const vaultRouter: any = getContractAddress('VaultRouter')[chainId];
 
-  const vaultRouter: any = getContractAddress('VaultRouter')[chainId];
+  // const relyResponse = (await contracts.getVaultContract()).rely(vaultRouter);
+  // (await relyResponse).wait();
 
-  const relyResponse = (await contracts.getVaultContract()).rely(vaultRouter);
-  (await relyResponse).wait();
-
-  await waitTime(50);
+  // await waitTime(50);
 
   return descent;
 }

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -5,11 +5,11 @@
  */
 
 import { Signer, ethers } from 'ethers';
-import ContractManager from '../contracts';
 import { Transaction } from './transactions';
 import { Internal } from './internal';
 import { getContractAddress } from '../contracts/getContractAddresses';
 import { Currency__factory, USDC__factory } from '../generated';
+import { Contract } from '../contracts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createError = (message?: any) => {
@@ -59,39 +59,43 @@ const approveUSDC = async (
 
 const waitTime = (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 
-const updateTestPrice = async (signer: Signer) => {
-  const chainId = (await signer?.provider?.getNetwork())?.chainId.toString();
+// const updateTestPrice = async (signer: Signer) => {
+//   const chainId = (await signer?.provider?.getNetwork())?.chainId.toString();
 
-  const collateralAddress: any = getContractAddress('USDC')[chainId!];
-  const feedContractAddress: any = getContractAddress('Feed')[chainId!];
-  const contract = new ContractManager(signer);
+//   const collateralAddress: any = getContractAddress('USDC')[chainId!];
+//   const feedContractAddress: any = getContractAddress('Feed')[chainId!];
+//   const contract = new ContractManager(signer);
 
-  await (await contract.getVaultContract()).updateFeedContract(feedContractAddress);
+//   await (await contract.getVaultContract()).updateFeedContract(feedContractAddress);
 
-  await waitTime(50);
+//   await waitTime(50);
 
-  const price = BigInt(1100) * BigInt(1e6);
+//   const price = BigInt(1100) * BigInt(1e6);
 
-  const priceUpdate = (await contract.getFeedContract()).mockUpdatePrice(collateralAddress, price);
-  (await priceUpdate).wait();
+//   const priceUpdate = (await contract.getFeedContract()).mockUpdatePrice(collateralAddress, price);
+//   (await priceUpdate).wait();
 
-  await waitTime(50);
-};
+//   await waitTime(50);
+// };
 
-const setMinterRole = async (signer: Signer, owner: string) => {
-  const chainId = (await signer?.provider?.getNetwork())?.chainId.toString();
+// const setMinterRole = async (signer: Signer, owner: string) => {
+//   const chainId = (await signer?.provider?.getNetwork())?.chainId.toString();
 
-  const vaultContractAddress: any = getContractAddress('Vault')[chainId!];
-  const contract = new ContractManager(signer);
+//   const vaultContractAddress: any = getContractAddress('Vault')[chainId!];
+//   const contract = new ContractManager(signer);
 
-  await (await contract.getCurrencyContract()).setMinterRole(vaultContractAddress);
+//   await (await contract.getCurrencyContract()).setMinterRole(vaultContractAddress);
 
-  await waitTime(50);
-};
+//   await waitTime(50);
+// };
 
 const getxNGNBalance = async (owner: any, signer?: Signer) => {
-  const contract = new ContractManager(signer!);
-  const balance = await (await contract.getCurrencyContract()).balanceOf(owner);
+  const chainId = (await signer?.provider?.getNetwork())?.chainId.toString();
+
+  const currencyContractAddress: any = getContractAddress('Currency')[chainId];
+
+  const currencyContract = Contract(currencyContractAddress, Currency__factory.abi, signer);
+  const balance = await currencyContract.balanceOf(owner);
 
   await waitTime(50);
 
@@ -129,8 +133,8 @@ export {
   createError,
   approveUSDC,
   waitTime,
-  updateTestPrice,
+  //  updateTestPrice,
   getxNGNBalance,
-  setMinterRole,
+  // setMinterRole,
   approvexNGN,
 };

--- a/src/services/vault.ts
+++ b/src/services/vault.ts
@@ -17,6 +17,7 @@ import {
   Currency__factory,
   VaultGetters__factory,
   VaultRouter__factory,
+  Vault__factory,
 } from '../generated/factories';
 import { getxNGNBalance } from '../libs/utils';
 import { Contract } from '../contracts';
@@ -31,6 +32,29 @@ export enum VaultOperations {
   MintCurrency = 2,
   BurnCurrency = 3,
 }
+const setupVault = async (
+  owner: string,
+  chainId: string,
+  transaction: Transaction,
+  internal: Internal,
+) => {
+  const vaultRouterAddress: any = getContractAddress('VaultRouter')[chainId];
+
+  // build transaction object
+  const to: any = getContractAddress('Vault')[chainId];
+  let iface = internal.getInterface(Vault__factory.abi);
+  const data = iface.encodeFunctionData('rely', [vaultRouterAddress]);
+
+  const txConfig = await internal.getTransactionConfig({
+    from: owner,
+    to,
+    data: data,
+  });
+
+  const relyResult = await transaction.send(txConfig, {});
+
+  return relyResult;
+};
 
 const collateralizeVault = async (
   amount: string,
@@ -213,4 +237,4 @@ const burnCurrency = async (
   return burnResult;
 };
 
-export { collateralizeVault, withdrawCollateral, mintCurrency, burnCurrency };
+export { collateralizeVault, withdrawCollateral, mintCurrency, burnCurrency, setupVault };

--- a/src/services/vault.ts
+++ b/src/services/vault.ts
@@ -7,14 +7,19 @@ import {
   parseUnits,
   parseEther,
   formatEther,
+  Signer,
 } from 'ethers';
 import { ICollateral, IContract } from '../types';
 import { Transaction } from '../libs/transactions';
 import { getContractAddress } from '../contracts/getContractAddresses';
 import { Internal } from '../libs/internal';
-import { VaultRouter__factory } from '../generated/factories';
-import ContractManager from '../contracts';
+import {
+  Currency__factory,
+  VaultGetters__factory,
+  VaultRouter__factory,
+} from '../generated/factories';
 import { getxNGNBalance } from '../libs/utils';
+import { Contract } from '../contracts';
 
 export enum VaultHealthFactor {
   UNSAFE = 'UNSAFE',
@@ -68,17 +73,20 @@ const withdrawCollateral = async (
   chainId: string,
   transaction: Transaction,
   internal: Internal,
-  contract: ContractManager,
+  signer: Signer,
 ) => {
   const collateralAddress: any = getContractAddress(collateral)[chainId];
   const vaultContractAddress: any = getContractAddress('Vault')[chainId];
+  const vaultGetterAddress: any = getContractAddress('VaultGetters')[chainId];
+
+  const vaultGetterContract = Contract(vaultGetterAddress, VaultGetters__factory.abi, signer);
 
   const _amount = BigInt(amount) * BigInt(1e6);
 
   const to: any = getContractAddress('VaultRouter')[chainId];
   let iface = internal.getInterface(VaultRouter__factory.abi);
 
-  const maxWithdrawable = (await contract.getVaultGetterContract()).getMaxWithdrawable(
+  const maxWithdrawable = await vaultGetterContract.getMaxWithdrawable(
     vaultContractAddress,
     collateralAddress,
     owner,
@@ -115,14 +123,17 @@ const mintCurrency = async (
   chainId: string,
   transaction: Transaction,
   internal: Internal,
-  contract: ContractManager,
+  signer: Signer,
 ) => {
   const collateralAddress: any = getContractAddress(collateral)[chainId];
   const vaultContractAddress: any = getContractAddress('Vault')[chainId];
+  const vaultGetterAddress: any = getContractAddress('VaultGetters')[chainId];
+
+  const vaultGetterContract = Contract(vaultGetterAddress, VaultGetters__factory.abi, signer);
 
   const _amount = BigInt(amount) * BigInt(1e18);
 
-  const maxBorrowable = (await contract.getVaultGetterContract()).getMaxBorrowable(
+  const maxBorrowable = await vaultGetterContract.getMaxBorrowable(
     vaultContractAddress,
     collateralAddress,
     owner,
@@ -162,14 +173,18 @@ const burnCurrency = async (
   chainId: string,
   transaction: Transaction,
   internal: Internal,
-  contract: ContractManager,
+  signer: Signer,
 ) => {
   const collateralAddress: any = getContractAddress(collateral)[chainId];
   const vaultContractAddress: any = getContractAddress('Vault')[chainId];
 
+  const currencyContractAddress: any = getContractAddress('Currency')[chainId];
+
+  const currencyContract = Contract(currencyContractAddress, Currency__factory.abi, signer);
+
   const _amount = BigInt(amount) * BigInt(1e18);
 
-  const balance = await (await contract.getCurrencyContract()).balanceOf(owner);
+  const balance = await currencyContract.balanceOf(owner);
 
   const formattedBalance = await formatEther(balance.toString());
 

--- a/test/getters.test.ts
+++ b/test/getters.test.ts
@@ -13,7 +13,7 @@ describe('Descent Protocol SDK Test', () => {
     descent = await Descent.create('https', {
       rpcUrl: rpcUrl,
       privateKey: process.env.PRIVATE_KEY,
-      collateral: ICollateral.USDC,
+      collateral: 'USDC',
     });
   }, 200000);
 

--- a/test/integration/descent.spec.ts
+++ b/test/integration/descent.spec.ts
@@ -1,5 +1,5 @@
 import { config } from 'dotenv';
-import Descent from '../../dist/esm/index.mjs';
+import Descent from '../../dist/index.es';
 import type { IDescentClass } from '../../dist/types/types';
 
 config();

--- a/test/vault.test.ts
+++ b/test/vault.test.ts
@@ -1,14 +1,7 @@
 import { config } from 'dotenv';
 import Descent, { DescentClass } from '../src';
 import { ICollateral } from '../src/types';
-import {
-  approveUSDC,
-  approvexNGN,
-  getxNGNBalance,
-  setMinterRole,
-  updateTestPrice,
-  waitTime,
-} from '../src/libs/utils';
+import { approveUSDC, approvexNGN, getxNGNBalance, waitTime } from '../src/libs/utils';
 import { Signer, ethers } from 'ethers';
 
 config();


### PR DESCRIPTION
Before now, we used dynamic imports to programmatically connect a contract to ethers using it's name. 

unfortunately dynamic imports like this don’t seem possible because imports happen at compile time so U can’t expressions in import statements.

In this PR, we refactored our contract initialization method to remove the need for dynamic imports.